### PR TITLE
Add audioop-lts to pip install list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ obs-websocket-py
 pycaw
 pygame
 pydub
+audioop-lts
 ffmpeg


### PR DESCRIPTION
Adds audioop-lts to pip install list to account for the people who need to install this library